### PR TITLE
Runtime efficiency improvement for computing distances between every two bounding boxes

### DIFF
--- a/utils/cluster.py
+++ b/utils/cluster.py
@@ -30,9 +30,17 @@ def centralize_bbox(bboxes):
 def compute_distances(bboxes):
     print("Computing distances")
     distances = np.zeros((len(bboxes), len(bboxes)))
+    area = (bboxes[:, 2] - bboxes[:, 0]) * (bboxes[:, 3] - bboxes[:, 1])
     for i in tqdm(range(len(bboxes)), total=len(bboxes)):
-        for j in range(len(bboxes)):
-            distances[i, j] = 1 - jaccard_index(bboxes[i, :], bboxes[j, :], (i, j))
+        xA = np.maximum(bboxes[:, 0], bboxes[i, 0])
+        yA = np.maximum(bboxes[:, 1], bboxes[i, 1])
+        xB = np.minimum(bboxes[:, 2], bboxes[i, 2])
+        yB = np.minimum(bboxes[:, 3], bboxes[i, 3])
+
+        intersection = (xB - xA) * (yB - yA)
+        union = area[i] + area[:] - intersection
+        iou = np.divide(intersection, union, out=np.zeros_like(union, dtype=float), where=union>0)
+        distances[i, :] = 1 - iou
 
     return distances
 


### PR DESCRIPTION
Thanks for your great work.

When I try to cluster the whole training set (159,424 bboxes), I found the speed for computing distances between every two bounding boxes is too slow, which requires ~40hrs to finish with a Intel(R) Xeon(R) Gold 6132 CPU @ 2.60GHz (56 cores).

So I rewrite the corresponding code so as to take the advantage of Numpy's parallelism. Now it can finish in 9mins.

However, the clustering itself is still pretty slow. I do not hack into the pyclustering though, I have no idea how much time it will need to finish with all the bboxes.